### PR TITLE
Adding remote interface for grabbing frame to SubprocVecEnv

### DIFF
--- a/baselines/common/vec_env/subproc_vec_env.py
+++ b/baselines/common/vec_env/subproc_vec_env.py
@@ -20,6 +20,8 @@ def worker(remote, parent_remote, env_fn_wrapper):
                 remote.send(ob)
             elif cmd == 'render':
                 remote.send(env.render(mode='rgb_array'))
+            elif cmd == 'grab_frame':
+                remote.send((env.unwrapped.sim.render(256, 256)))
             elif cmd == 'close':
                 remote.close()
                 break


### PR DESCRIPTION
SubprocVecEnv currently offers a 'render' remote command that allows on-screen rendering. This PR implements a 'grab_frame' remote command to grab a frame without rendering on-screen.